### PR TITLE
Rollback scrollable parent change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed the position data when a parent element was scrolled
 
-### Added
-
--   New `scrollableParents` field is now returned with `PositionData`
-
 ## [1.0.1] - 2023-11-14
 
 <small>[Compare to previous release][comp:1.0.1]</small>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Position (A JavaScript package)
 
-A small package to help position a floating element. This can be positioned relative to another element or to a mouse event.
+A small package to help position a floating element. This can be positioned relative to another elements' current screen position, or to a mouse event.
 
 ### Links
 

--- a/src/Types/PositionData.ts
+++ b/src/Types/PositionData.ts
@@ -1,5 +1,4 @@
 export type PositionData = {
     top: string;
     left: string;
-    scrollableParents: HTMLElement[];
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,8 @@ import { PositionData } from './Types/PositionData';
  * @returns object with a top and left value in the form `{number}px`
  */
 function position(options: IOptions): PositionData {
-    const { _bodyRect, _anchorRect, _targetRect, scrollableParents } = initialisePrivateFields();
-
-    const myPos = Helpers.parse(
+    const { _bodyRect, _anchorRect, _targetRect } = initialisePrivateFields(),
+        myPos = Helpers.parse(
             options.my,
             options.defaults
                 ? Helpers.parse(options.defaults.my)
@@ -44,7 +43,6 @@ function position(options: IOptions): PositionData {
         return {
             left: calculateLeft(myPos, atPos).value.toString() + 'px',
             top: calculateTop(myPos, atPos).value.toString() + 'px',
-            scrollableParents,
             // @ts-ignore
             ...(options.debug === true
                 ? { _bodyRect, _anchorRect, _targetRect }
@@ -57,7 +55,6 @@ function position(options: IOptions): PositionData {
     return {
         top: pos.top.toString() + 'px',
         left: pos.left.toString() + 'px',
-        scrollableParents,
         // @ts-ignore
         ...(options.debug === true
             ? { _bodyRect, _anchorRect, _targetRect }
@@ -81,41 +78,33 @@ function position(options: IOptions): PositionData {
                               return '{}';
                           },
                       }
-                    : options.anchor.getBoundingClientRect();
+                    : options.anchor.getBoundingClientRect(),
+            originalDisplay = options.target.style.display,
+            _targetRect = options.target.getBoundingClientRect();
 
-        const originalDisplay = options.target.style.display;
         options.target.style.display = 'block';
-
-        const _targetRect = options.target.getBoundingClientRect(),
-            scrollableParents : HTMLElement[] = [];
-
         options.target.style.display = originalDisplay;
 
         // Adjust to scrollable regions
         if (options.anchor instanceof HTMLElement) {
-            let parent = options.anchor.parentElement;
-
-            while (parent !== null && parent.tagName !== 'HTML') {
-                // Check if scrollable
-                if (parent.scrollHeight > parent.clientHeight)
-                    scrollableParents.push(parent)
-
-                parent = parent.parentElement;
-            }
-
             // Finally, adjust for window scroll position
             const doc = document.documentElement;
             _anchorRect.y +=
-                (window.scrollY || doc.scrollTop) - (doc.clientTop || 0);
+                (window.scrollY ||
+                    document.documentElement.scrollTop ||
+                    document.body.scrollTop ||
+                    0) - (doc.clientTop || 0);
             _anchorRect.x +=
-                (window.scrollX || doc.scrollLeft) - (doc.clientLeft || 0);
+                (window.scrollX ||
+                    document.documentElement.scrollLeft ||
+                    document.body.scrollLeft ||
+                    0) - (doc.clientLeft || 0);
         }
 
         return {
             _bodyRect,
             _anchorRect,
             _targetRect,
-            scrollableParents
         };
     }
 


### PR DESCRIPTION
This package is simple, no need to overcomplicate with returning scrollable parents. Some users may want to attach to every parent up the chain. Because of this, I have rolled back the previous update
-    Also did some very minor code tidying